### PR TITLE
fix: stabilize ./... tests and add bounded mirror reload timeout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,9 @@ cli/sty/assets/*.tgz
 
 bin/dist
 bin/dist2
-tmp/
+!tmp/
+tmp/*
+!tmp/go.mod
 dist/
 pig
 .DS_Store

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ build-linux-arm64:
 	CGO_ENABLED=0 GOOS=linux  GOARCH=arm64 go build -a -ldflags "$(LD_FLAGS) -extldflags '-static'" -o pig
 	upx pig
 
-r: release
+rel: release
 release: release-linux
 release-linux: linux-amd64 linux-arm64
 linux-amd64: clean build-linux-amd64
@@ -85,11 +85,11 @@ gr-prod-release:
 	goreleaser release --clean
 
 # Check goreleaser configuration
-gr-check: goreleaser-install
+gr-check: gr-install
 	goreleaser check
 
 # New main release task using goreleaser
-release-new: goreleaser-release
+release-new: gr-release
 
 
 ###############################################################
@@ -101,9 +101,9 @@ upload:
 tag:
 	git tag -d $(VERSION) || true
 	git tag $(VERSION)
-r: run
 run:
 	go run main.go
+r: run
 b: build
 build:
 	go build -ldflags "$(LD_FLAGS)" -o pig
@@ -111,10 +111,12 @@ c: clean
 clean:
 	rm -rf pig
 
-d:
+docs-serve:
 	hugo serve
-b:
+docs-build:
 	hugo --minify
+d: docs-serve
+db: docs-build
 
 ###############################################################
 #                         Testing                            #
@@ -132,6 +134,6 @@ amd:
 2j: amd
 	scp pig jp:/tmp/pig; ssh jp sudo mv /tmp/pig /usr/bin/pig
 
-.PHONY: run build clean build-linux-amd64 build-linux-arm64 release release-linux linux-amd64 linux-arm64 \
- goreleaser-install goreleaser-snapshot goreleaser-build goreleaser-release goreleaser-test-release \
- goreleaser-check release-new goreleaser-local
+.PHONY: run build clean rel release release-linux build-linux-amd64 build-linux-arm64 linux-amd64 linux-arm64 \
+ gr-install gr-snapshot gr-build gr-local gr-release gr-prod-release gr-check release-new \
+ upload tag docs-serve docs-build d db r b c arm amd 2m 2c 2a 2j

--- a/cli/ext/reload.go
+++ b/cli/ext/reload.go
@@ -22,8 +22,6 @@ func ReloadCatalogResult() *output.Result {
 		config.RepoPigstyCC + "/ext/data/extension.csv",
 	}
 
-	ctx := context.Background()
-
 	// Success criteria: downloaded content must be a valid extension catalog.
 	var extNum int
 	validate := func(content []byte) error {
@@ -35,7 +33,7 @@ func ReloadCatalogResult() *output.Result {
 		return nil
 	}
 
-	content, sourceURL, err := utils.FetchFirstValid(ctx, urls, validate)
+	content, sourceURL, err := utils.FetchFirstValidWithTimeout(0, urls, validate)
 	if err != nil {
 		msg := "failed to download extension catalog"
 		var ne interface{ Timeout() bool }

--- a/cli/repo/reload.go
+++ b/cli/repo/reload.go
@@ -25,8 +25,6 @@ func ReloadRepoCatalogWithResult() *output.Result {
 		config.RepoPigstyCC + "/ext/data/repo.yml",
 	}
 
-	ctx := context.Background()
-
 	// Success criteria: downloaded content must be a valid repo catalog.
 	var repos []Repository
 	validate := func(content []byte) error {
@@ -38,7 +36,7 @@ func ReloadRepoCatalogWithResult() *output.Result {
 		return nil
 	}
 
-	content, sourceURL, err := utils.FetchFirstValid(ctx, urls, validate)
+	content, sourceURL, err := utils.FetchFirstValidWithTimeout(0, urls, validate)
 	if err != nil {
 		msg := "failed to download repo catalog"
 		var ne interface{ Timeout() bool }

--- a/tmp/go.mod
+++ b/tmp/go.mod
@@ -1,0 +1,3 @@
+module pig/tmp
+
+go 1.26.0


### PR DESCRIPTION
## Summary
- fix issue #7 by preventing root `go test ./...` from entering ad-hoc `tmp/` programs
- fix issue #9 by simplifying `PutFile` temp-file fallback and removing redundant temp file handle creation
- optimize Makefile release/dev aliases and repair broken target wiring (`gr-check`, `release-new`)
- align reload timeout behavior with existing timeout-based flows by introducing `FetchFirstValidWithTimeout` and using it in `ext reload` / `repo reload`

## Details
- `.gitignore`: keep `tmp/` ignored except tracked `tmp/go.mod`
- `tmp/go.mod`: split ad-hoc scripts into nested module so package discovery for root module excludes `tmp`
- `internal/utils/utils.go`: remove redundant `os.Create` in `PutFile`, use direct temp path write + sudo move
- `internal/utils/mirror.go`: add `DefaultMirrorFetchTimeout` + `FetchFirstValidWithTimeout`
- `cli/ext/reload.go`, `cli/repo/reload.go`: switch mirror fetch to timeout wrapper
- `internal/utils/mirror_test.go`: add deadline test coverage
- `Makefile`: remove conflicting aliases and fix target references

## Validation
- `go test ./...`
- `go vet ./...`
- `go test -race ./internal/utils ./cli/ext ./cli/repo ./cmd`
- `make -n r`
- `make -n rel`
- `make -n b`
- `make -n release-new`
- `make -n gr-check`
