### PR TITLE
fix(pt): prepend CLUSTER_NAME for restart/reinit/switchover/failover (fixes #29)

### DIFF
--- a/cli/patroni/patroni.go
+++ b/cli/patroni/patroni.go
@@ -18,6 +18,40 @@ const DefaultConfigPath = "/etc/patroni/patroni.yml"
 // DefaultDBSU is the default database superuser
 const DefaultDBSU = "postgres"
 
+// GetClusterName returns the cluster scope name read from `scope:` in the
+// patroni config file. Required for patronictl subcommands that take a
+// positional CLUSTER_NAME (restart, reinit, switchover, failover); the
+// `-c <config>` flag alone does NOT supply scope to those subcommands.
+//
+// Falls back to reading via DBSU when the config file isn't world-readable
+// (typical Pigsty layout: /pg/conf/<scope>.yml is postgres:postgres 0640).
+func GetClusterName(dbsu string) (string, error) {
+	content, err := os.ReadFile(DefaultConfigPath)
+	if err != nil {
+		if dbsu == "" {
+			dbsu = DefaultDBSU
+		}
+		text, dbsuErr := utils.DBSUCommandOutput(dbsu, []string{"cat", DefaultConfigPath})
+		if dbsuErr != nil {
+			return "", fmt.Errorf("cannot read %s (direct: %v; as %s: %v)", DefaultConfigPath, err, dbsu, dbsuErr)
+		}
+		content = []byte(text)
+	}
+
+	for _, line := range strings.Split(string(content), "\n") {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "scope:") {
+			rest := strings.TrimSpace(strings.TrimPrefix(line, "scope:"))
+			rest = strings.Trim(rest, "\"'")
+			if rest == "" {
+				return "", fmt.Errorf("scope: key in %s has empty value", DefaultConfigPath)
+			}
+			return rest, nil
+		}
+	}
+	return "", fmt.Errorf("scope: key not found in %s", DefaultConfigPath)
+}
+
 // runPatronictl executes patronictl with given arguments as DBSU
 func runPatronictl(dbsu string, args []string) error {
 	binPath, err := exec.LookPath("patronictl")
@@ -168,32 +202,37 @@ type RestartOptions struct {
 	Pending bool   // only restart members with pending restart
 }
 
+// buildRestartArgs builds the positional + flag args for `patronictl restart`.
+// patronictl restart requires CLUSTER_NAME as the first positional argument
+// (the `-c <config>` flag does NOT supply scope here, unlike pause/resume/list).
+func buildRestartArgs(cluster string, opts *RestartOptions) []string {
+	args := []string{"restart", cluster}
+
+	if opts == nil {
+		return args
+	}
+	if opts.Role != "" {
+		args = append(args, "--role", opts.Role)
+	}
+	if opts.Member != "" {
+		args = append(args, opts.Member)
+	}
+	if opts.Force {
+		args = append(args, "--force")
+	}
+	if opts.Pending {
+		args = append(args, "--pending")
+	}
+	return args
+}
+
 // Restart restarts PostgreSQL via patronictl restart
 func Restart(dbsu string, opts *RestartOptions) error {
-	args := []string{"restart"}
-
-	if opts != nil {
-		// Add role filter if specified
-		if opts.Role != "" {
-			args = append(args, "--role", opts.Role)
-		}
-
-		// Add member name if specified (positional argument after cluster)
-		// patronictl restart <cluster> [member]
-		// Since we use -c config, cluster name is auto-detected
-		if opts.Member != "" {
-			args = append(args, opts.Member)
-		}
-
-		if opts.Force {
-			args = append(args, "--force")
-		}
-		if opts.Pending {
-			args = append(args, "--pending")
-		}
+	cluster, err := GetClusterName(dbsu)
+	if err != nil {
+		return fmt.Errorf("restart: %w", err)
 	}
-
-	return runPatronictl(dbsu, args)
+	return runPatronictl(dbsu, buildRestartArgs(cluster, opts))
 }
 
 // ReinitOptions holds options for patronictl reinit
@@ -203,23 +242,35 @@ type ReinitOptions struct {
 	Wait   bool   // wait for reinit to complete
 }
 
-// Reinit reinitializes a cluster member via patronictl reinit
-func Reinit(dbsu string, opts *ReinitOptions) error {
-	if opts == nil || opts.Member == "" {
-		return fmt.Errorf("member name is required for reinit")
+// buildReinitArgs builds the positional + flag args for `patronictl reinit`.
+// Required positional layout: reinit CLUSTER_NAME MEMBER_NAME.
+func buildReinitArgs(cluster string, opts *ReinitOptions) []string {
+	args := []string{"reinit", cluster}
+	if opts == nil {
+		return args
 	}
-
-	args := []string{"reinit"}
-	args = append(args, opts.Member)
-
+	if opts.Member != "" {
+		args = append(args, opts.Member)
+	}
 	if opts.Force {
 		args = append(args, "--force")
 	}
 	if opts.Wait {
 		args = append(args, "--wait")
 	}
+	return args
+}
 
-	return runPatronictl(dbsu, args)
+// Reinit reinitializes a cluster member via patronictl reinit
+func Reinit(dbsu string, opts *ReinitOptions) error {
+	if opts == nil || opts.Member == "" {
+		return fmt.Errorf("member name is required for reinit")
+	}
+	cluster, err := GetClusterName(dbsu)
+	if err != nil {
+		return fmt.Errorf("reinit: %w", err)
+	}
+	return runPatronictl(dbsu, buildReinitArgs(cluster, opts))
 }
 
 // SwitchoverOptions holds options for patronictl switchover
@@ -310,26 +361,35 @@ func buildSwitchoverCommand(opts *SwitchoverOptions) string {
 	return strings.Join(args, " ")
 }
 
+// buildSwitchoverArgs builds the args for `patronictl switchover`.
+// Required positional layout: switchover CLUSTER_NAME [--leader X --candidate Y ...].
+func buildSwitchoverArgs(cluster string, opts *SwitchoverOptions) []string {
+	args := []string{"switchover", cluster}
+	if opts == nil {
+		return args
+	}
+	if opts.Leader != "" {
+		args = append(args, "--leader", opts.Leader)
+	}
+	if opts.Candidate != "" {
+		args = append(args, "--candidate", opts.Candidate)
+	}
+	if opts.Force {
+		args = append(args, "--force")
+	}
+	if opts.Scheduled != "" {
+		args = append(args, "--scheduled", opts.Scheduled)
+	}
+	return args
+}
+
 // Switchover performs a planned switchover via patronictl switchover
 func Switchover(dbsu string, opts *SwitchoverOptions) error {
-	args := []string{"switchover"}
-
-	if opts != nil {
-		if opts.Leader != "" {
-			args = append(args, "--leader", opts.Leader)
-		}
-		if opts.Candidate != "" {
-			args = append(args, "--candidate", opts.Candidate)
-		}
-		if opts.Force {
-			args = append(args, "--force")
-		}
-		if opts.Scheduled != "" {
-			args = append(args, "--scheduled", opts.Scheduled)
-		}
+	cluster, err := GetClusterName(dbsu)
+	if err != nil {
+		return fmt.Errorf("switchover: %w", err)
 	}
-
-	return runPatronictl(dbsu, args)
+	return runPatronictl(dbsu, buildSwitchoverArgs(cluster, opts))
 }
 
 // FailoverOptions holds options for patronictl failover
@@ -399,18 +459,27 @@ func buildFailoverCommand(opts *FailoverOptions) string {
 	return strings.Join(args, " ")
 }
 
+// buildFailoverArgs builds the args for `patronictl failover`.
+// Required positional layout: failover CLUSTER_NAME [--candidate Y ...].
+func buildFailoverArgs(cluster string, opts *FailoverOptions) []string {
+	args := []string{"failover", cluster}
+	if opts == nil {
+		return args
+	}
+	if opts.Candidate != "" {
+		args = append(args, "--candidate", opts.Candidate)
+	}
+	if opts.Force {
+		args = append(args, "--force")
+	}
+	return args
+}
+
 // Failover performs an unplanned failover via patronictl failover
 func Failover(dbsu string, opts *FailoverOptions) error {
-	args := []string{"failover"}
-
-	if opts != nil {
-		if opts.Candidate != "" {
-			args = append(args, "--candidate", opts.Candidate)
-		}
-		if opts.Force {
-			args = append(args, "--force")
-		}
+	cluster, err := GetClusterName(dbsu)
+	if err != nil {
+		return fmt.Errorf("failover: %w", err)
 	}
-
-	return runPatronictl(dbsu, args)
+	return runPatronictl(dbsu, buildFailoverArgs(cluster, opts))
 }

--- a/cli/patroni/patroni_test.go
+++ b/cli/patroni/patroni_test.go
@@ -5,6 +5,162 @@ import (
 	"testing"
 )
 
+// argsHas reports whether `want` appears at args[i] for any i. argsHasInOrder
+// is the stricter variant: returns true only if every want appears in args
+// in the given order (possibly non-contiguous).
+func argsHas(args []string, want string) bool {
+	for _, a := range args {
+		if a == want {
+			return true
+		}
+	}
+	return false
+}
+
+func argsHasInOrder(args []string, wants ...string) bool {
+	i := 0
+	for _, a := range args {
+		if i < len(wants) && a == wants[i] {
+			i++
+		}
+	}
+	return i == len(wants)
+}
+
+func TestBuildRestartArgs(t *testing.T) {
+	const cluster = "pg-nms"
+
+	tests := []struct {
+		name        string
+		opts        *RestartOptions
+		wantPrefix  []string // first N args, in order
+		wantInOrder []string // must appear in args in this order
+		notWant     []string // must NOT appear anywhere
+	}{
+		{
+			name:       "nil opts → just restart + cluster",
+			opts:       nil,
+			wantPrefix: []string{"restart", cluster},
+			notWant:    []string{"--force", "--pending", "--role"},
+		},
+		{
+			name:       "pending + force, no member",
+			opts:       &RestartOptions{Pending: true, Force: true},
+			wantPrefix: []string{"restart", cluster},
+			wantInOrder: []string{
+				"restart", cluster, "--force", "--pending",
+			},
+			notWant: []string{"--role"},
+		},
+		{
+			name:       "specific member + force",
+			opts:       &RestartOptions{Member: "pg-nms-1", Force: true},
+			wantPrefix: []string{"restart", cluster},
+			wantInOrder: []string{
+				"restart", cluster, "pg-nms-1", "--force",
+			},
+		},
+		{
+			name:       "role filter",
+			opts:       &RestartOptions{Role: "replica", Force: true},
+			wantPrefix: []string{"restart", cluster},
+			wantInOrder: []string{
+				"restart", cluster, "--role", "replica", "--force",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := buildRestartArgs(cluster, tt.opts)
+
+			for i, w := range tt.wantPrefix {
+				if i >= len(got) || got[i] != w {
+					t.Errorf("prefix mismatch at %d: want %q, got args=%v", i, w, got)
+				}
+			}
+			if len(tt.wantInOrder) > 0 && !argsHasInOrder(got, tt.wantInOrder...) {
+				t.Errorf("want subsequence %v in args, got %v", tt.wantInOrder, got)
+			}
+			for _, n := range tt.notWant {
+				if argsHas(got, n) {
+					t.Errorf("did not want %q in args, got %v", n, got)
+				}
+			}
+		})
+	}
+}
+
+func TestBuildReinitArgs(t *testing.T) {
+	const cluster = "pg-nms"
+
+	got := buildReinitArgs(cluster, &ReinitOptions{Member: "pg-nms-2", Force: true, Wait: true})
+	if !argsHasInOrder(got, "reinit", cluster, "pg-nms-2", "--force", "--wait") {
+		t.Errorf("want reinit %s pg-nms-2 --force --wait in order, got %v", cluster, got)
+	}
+
+	got = buildReinitArgs(cluster, nil)
+	if len(got) != 2 || got[0] != "reinit" || got[1] != cluster {
+		t.Errorf("nil opts: want [reinit %s], got %v", cluster, got)
+	}
+}
+
+func TestBuildSwitchoverArgs(t *testing.T) {
+	const cluster = "pg-nms"
+
+	got := buildSwitchoverArgs(cluster, &SwitchoverOptions{
+		Leader:    "pg-nms-1",
+		Candidate: "pg-nms-2",
+		Force:     true,
+		Scheduled: "2026-05-13T16:30:00",
+	})
+	if !argsHasInOrder(got, "switchover", cluster, "--leader", "pg-nms-1", "--candidate", "pg-nms-2") {
+		t.Errorf("want switchover %s --leader pg-nms-1 --candidate pg-nms-2 in order, got %v", cluster, got)
+	}
+	if !argsHas(got, "--force") || !argsHas(got, "--scheduled") {
+		t.Errorf("want --force and --scheduled in args, got %v", got)
+	}
+
+	got = buildSwitchoverArgs(cluster, nil)
+	if len(got) != 2 || got[0] != "switchover" || got[1] != cluster {
+		t.Errorf("nil opts: want [switchover %s], got %v", cluster, got)
+	}
+}
+
+func TestBuildFailoverArgs(t *testing.T) {
+	const cluster = "pg-nms"
+
+	got := buildFailoverArgs(cluster, &FailoverOptions{Candidate: "pg-nms-2", Force: true})
+	if !argsHasInOrder(got, "failover", cluster, "--candidate", "pg-nms-2", "--force") {
+		t.Errorf("want failover %s --candidate pg-nms-2 --force in order, got %v", cluster, got)
+	}
+
+	got = buildFailoverArgs(cluster, nil)
+	if len(got) != 2 || got[0] != "failover" || got[1] != cluster {
+		t.Errorf("nil opts: want [failover %s], got %v", cluster, got)
+	}
+}
+
+// TestPatronictlPositionalContract documents the constraint that motivated the
+// CLUSTER_NAME prepend across Restart / Reinit / Switchover / Failover.
+// Unlike pause / resume / list, those four patronictl subcommands require
+// CLUSTER_NAME as the first positional argument; `-c <config>` does NOT supply
+// scope to them. If a future refactor drops the prepend, this test fails fast.
+func TestPatronictlPositionalContract(t *testing.T) {
+	const cluster = "scope-name"
+
+	for name, args := range map[string][]string{
+		"restart":    buildRestartArgs(cluster, nil),
+		"reinit":     buildReinitArgs(cluster, nil),
+		"switchover": buildSwitchoverArgs(cluster, nil),
+		"failover":   buildFailoverArgs(cluster, nil),
+	} {
+		if len(args) < 2 || args[1] != cluster {
+			t.Errorf("%s: cluster name must appear at args[1], got %v", name, args)
+		}
+	}
+}
+
 func TestBuildSwitchoverPlan(t *testing.T) {
 	opts := &SwitchoverOptions{
 		Leader:    "pg-1",


### PR DESCRIPTION
## Summary

Fixes #29 — `pig pt restart`, `pig pt reinit`, `pig pt switchover`, and `pig pt failover` all fail because the underlying `patronictl` invocation omits the required `CLUSTER_NAME` positional argument.

Unlike `patronictl pause/resume/list`, those four subcommands do **not** accept `-c <config>` as a substitute for scope — they require `CLUSTER_NAME` as the first positional argument.

## Reproduction (from #29)

```bash
$ sudo -u dba pig pt restart --pending -f
$ /usr/bin/patronictl -c /etc/patroni/patroni.yml restart --force --pending
Error: Missing argument 'CLUSTER_NAME'.

$ sudo -u dba pig pt restart pg-nms-1 -f
# patronictl gets `restart --force pg-nms-1` → treats pg-nms-1 as CLUSTER_NAME
# → etcd PermissionDenied (no such cluster key)

$ sudo -u dba pig pt restart pg-nms pg-nms-1 -f
# pig only consumes args[0] = "pg-nms" → patronictl runs `restart pg-nms --force`
# → restarts WHOLE cluster instead of just pg-nms-1 (surprising and undocumented)
```

## Fix shape

- New exported `GetClusterName(dbsu)` in `cli/patroni/patroni.go` — reads `scope:` from `/etc/patroni/patroni.yml`, falls back to `utils.DBSUCommandOutput(dbsu, [\"cat\", DefaultConfigPath])` for the typical Pigsty layout where the file is `postgres:postgres 0640`.
- Pure args builders extracted: `buildRestartArgs / buildReinitArgs / buildSwitchoverArgs / buildFailoverArgs` — testable without exec'ing patronictl. Each prepends \`cluster\` immediately after the verb.
- `Restart / Reinit / Switchover / Failover` now resolve the cluster name once at the top, then call their respective builder + `runPatronictl`.
- Misleading comment in original \`Restart\` (\"Since we use -c config, cluster name is auto-detected\" — only true for pause/resume/list) removed.

\`cli/context/context.go\` has a similar helper (\`getPatroniClusterName\`) — left untouched to keep this PR focused; happy to follow up with a refactor to reuse \`GetClusterName\` if you'd like.

## Tests

\`cli/patroni/patroni_test.go\` extended:

- \`TestBuildRestartArgs\` — table-driven, 4 cases (nil opts / pending+force / specific member+force / role filter). Verifies cluster appears at \`args[1]\` and the flag/positional layout matches patronictl's CLI contract.
- \`TestBuildReinitArgs / TestBuildSwitchoverArgs / TestBuildFailoverArgs\` — same shape for the other three commands.
- \`TestPatronictlPositionalContract\` — regression guard. Documents the invariant inline so a future refactor that drops the prepend fails fast with a self-explanatory message.

## Validation

- \`go build ./...\` clean
- \`go vet ./...\` clean
- \`go test ./...\` — every package green (\`cli/patroni\` 3.818s, full suite ~80s)
- Manually exercised the fix path on a 2-node Pigsty v4.3 cluster (Ubuntu 24.04, patroni 4.1.2, etcd3 DCS) — \`Restart\` now passes through to \`patronictl restart pg-nms [member] --force --pending\` correctly, clears pending restart markers as expected.

## Out of scope (kept minimal)

- \`cli/context/context.go\`'s \`getPatroniClusterName\` (duplicate logic) — happy to refactor in a follow-up.
- \`buildSwitchoverCommand\` / \`buildFailoverCommand\` (for the Plan display surface) — those return what the user would TYPE (\`pig pt switchover ...\`), not patronictl args, so they're correct as-is.